### PR TITLE
fix/empty-search-returns-all-regioes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install dependencies
 npm install
 ```
 
-First, run the development server:
+Then, run the development server:
 
 ```bash
 npm run dev

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -21,6 +21,16 @@ export type RegionTree = Array<{
 
 function findAllRegionsByQuery(query: string): Region[] | undefined {
   const queryLower = query.toLowerCase();
+  // If we don't have a query return the first 10 regions
+  // This mimics "pagination" of the regions without actually needing to
+  // implement pagination
+  if (!query) {
+    return regionCodes.slice(0, 10).map((region) => ({
+      name: region.name,
+      code: region.code,
+    }));
+  }
+
   const results: Region[] = [];
   for (const region of regionCodes) {
     if (region.name.toLowerCase().includes(queryLower)) {


### PR DESCRIPTION
This shortcuts the slow logic of looping through all regions and returns the first 10 instead. 

It's not ideal (ideally we'd paginate this properly) but it stops us returning a 65k blob of data back to the FE and crashing it.