### PR TITLE
Bug/recent sightings in URL 

### DIFF
--- a/src/app/RegionCodeSearch.tsx
+++ b/src/app/RegionCodeSearch.tsx
@@ -47,7 +47,10 @@ export function RegionCodeSearch() {
               key={result.item.code}
               // TODO: abstract this into an Anchor component to share styles
               className="font-medium text-primary underline underline-offset-2"
-              href={`/recent/${regionPath}`}
+              href={{
+                pathname: `recent/${regionPath}`,
+                query: { name: result.item.name },
+              }}
             >
               View recent sightings in {result.item.fullHierarchyName}
             </Link>

--- a/src/app/RegionCodeSearch.tsx
+++ b/src/app/RegionCodeSearch.tsx
@@ -48,8 +48,8 @@ export function RegionCodeSearch() {
               // TODO: abstract this into an Anchor component to share styles
               className="font-medium text-primary underline underline-offset-2"
               href={{
-                pathname: `recent/${regionPath}`,
-                query: { name: result.item.name },
+                pathname: `/recent/${regionPath}`,
+                query: { name: `${result.item.name}` },
               }}
             >
               View recent sightings in {result.item.fullHierarchyName}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ export default async function Home() {
   return (
     <>
       <h1 className="mb-12 text-4xl">
-        Recent bird sightings by region
+        Recent bird sightings by region{" "}
         <span role="img" aria-label="bird">
           🐦
         </span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 import { RegionCodeSearch } from "./RegionCodeSearch";
 
 export default async function Home() {

--- a/src/app/recent/[...regionCodeSlug]/page.tsx
+++ b/src/app/recent/[...regionCodeSlug]/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import {
   Card,
@@ -9,7 +7,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { EBIRD_BASE_API_URL } from "@/constants";
-import { useSearchParams } from "next/navigation";
 
 type RecentSightingsResponse = Array<{
   speciesCode: string;
@@ -152,22 +149,21 @@ async function BirdCard({ sighting }: { sighting: Sighting }) {
 
 export default async function RecentSightingsPage({
   params,
+  searchParams,
 }: {
   params: {
     regionCodeSlug: string[];
   };
+  searchParams: { name: string };
 }) {
   // TODO: make a function that finds a RegionCode by regionCodeSlug
   // So that we can show the region name at the top of the page
-
-  const searchParams = useSearchParams();
-  const regionName = searchParams.get("name") || "this region.";
   const regionCode = params.regionCodeSlug.join("-").toUpperCase();
   const sightings = await getRecentSightings(regionCode);
   return (
     <div className="flex min-h-screen flex-col items-center justify-between p-4 md:p-24">
       <h1 className="mb-12 text-4xl">
-        Recent bird sightings in {regionName}{" "}
+        Recent bird sightings in {searchParams.name}{" "}
         <span role="img" aria-label="bird">
           🐦
         </span>

--- a/src/app/recent/[...regionCodeSlug]/page.tsx
+++ b/src/app/recent/[...regionCodeSlug]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import {
   Card,
@@ -7,6 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { EBIRD_BASE_API_URL } from "@/constants";
+import { useSearchParams } from "next/navigation";
 
 type RecentSightingsResponse = Array<{
   speciesCode: string;
@@ -157,12 +160,14 @@ export default async function RecentSightingsPage({
   // TODO: make a function that finds a RegionCode by regionCodeSlug
   // So that we can show the region name at the top of the page
 
+  const searchParams = useSearchParams();
+  const regionName = searchParams.get("name") || "this region.";
   const regionCode = params.regionCodeSlug.join("-").toUpperCase();
   const sightings = await getRecentSightings(regionCode);
   return (
     <div className="flex min-h-screen flex-col items-center justify-between p-4 md:p-24">
       <h1 className="mb-12 text-4xl">
-        Recent bird sightings in East Sussex{" "}
+        Recent bird sightings in {regionName}{" "}
         <span role="img" aria-label="bird">
           🐦
         </span>


### PR DESCRIPTION
## Description
-Once a region has been selected after a search, the heading reads "Recent bird sightings in {region.name}" as opposed to "Recent bird sightings in East Sussex".
-RegionCodeSearch.tsx Link passes query: { result.item.name }. URL passes regionName info as well as regionCode info.
-In regionCodeSlug.tsx Page component uses searchParams to take region name. This is used in the heading.

## **Visual Change**
**Before**
<img width="142" alt="Screenshot 2024-08-07 at 12 07 38" src="https://github.com/user-attachments/assets/3ecc04df-136c-4b7d-a060-4343f5717ba3">
<img width="685" alt="Screenshot 2024-08-07 at 12 07 47" src="https://github.com/user-attachments/assets/0a025707-b4b1-4460-b0b0-2521d1713c15">


**After**
<img width="200" alt="Screenshot 2024-08-07 at 12 06 47" src="https://github.com/user-attachments/assets/5e4d23c4-92f3-4705-b9a0-03aab35948ab">
<img width="592" alt="Screenshot 2024-08-07 at 12 06 55" src="https://github.com/user-attachments/assets/cb12ada4-2c46-48d8-aea7-2fbf290fd211">
