### PR TITLE
# Homepage Redesign - Draft 01

### DIFF
--- a/src/app/components/top-nav.tsx
+++ b/src/app/components/top-nav.tsx
@@ -75,9 +75,12 @@ function MobileNav() {
 
 export function TopNav() {
   return (
-    <div className="sticky top-0 z-10 flex flex-col bg-white">
-      <div className="flex flex-row p-2">
+    <div className="sticky top-0 z-10 flex flex-col bg-[#eee8e4]">
+      <div className="flex flex-row items-center justify-between p-2">
         <MobileNav />
+        <h1 className="text-chart-1 text-2xl">bird</h1>
+        {/* A little cheat here to centre the heading in the nav bar */}
+        <h1 className="opacity-0">bird</h1>
       </div>
       <Separator />
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
+/* .primary {
+  background-color: hsl(25, 86%, 50%);
+}
+.secondary {
+  background-color: hsl(200, 79%, 38%);
+}
+.tertiary {
+  background-color: rgb(20, 219, 170);
+}
+.quaternary {
+  background-color: hsl(204, 26%, 38%);
+} */
+
 @layer base {
   :root {
     --background: 0 0% 100%;
@@ -10,9 +23,9 @@
     --card-foreground: 20 14.3% 4.1%;
     --popover: 0 0% 100%;
     --popover-foreground: 20 14.3% 4.1%;
-    --primary: 24.6 95% 53.1%;
+    --primary: 25, 86%, 50%;
     --primary-foreground: 60 9.1% 97.8%;
-    --secondary: 60 4.8% 95.9%;
+    --secondary: 200 79% 38%;
     --secondary-foreground: 24 9.8% 10%;
     --muted: 60 4.8% 95.9%;
     --muted-foreground: 25 5.3% 44.7%;
@@ -20,9 +33,9 @@
     --accent-foreground: 24 9.8% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 60 9.1% 97.8%;
-    --border: 20 5.9% 90%;
+    --border: 24, 4%, 75%;
     --input: 20 5.9% 90%;
-    --ring: 24.6 95% 53.1%;
+    --ring: 25, 86%, 50%;
     --radius: 0.75rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={inter.className} style={{ backgroundColor: "#eee8e4" }}>
         <main>
           <div className="grid min-h-dvh grid-rows-[auto_1fr]">
             <TopNav />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@/components/ui/button";
-import { ChevronRightIcon } from "@heroicons/react/24/solid";
+import { MapIcon, MagnifyingGlassCircleIcon } from "@heroicons/react/16/solid";
 import Link, { LinkProps } from "next/link";
 
 function LinkListItem({ children }: { children: React.ReactNode }) {
@@ -9,26 +8,57 @@ function LinkListItem({ children }: { children: React.ReactNode }) {
 function StyledLink({
   href,
   children,
-}: LinkProps & { children: React.ReactNode }) {
+  description,
+  backgroundColor,
+  icon,
+}: LinkProps & { children: React.ReactNode } & {
+  description: string;
+  backgroundColor: string;
+  icon: React.ReactNode;
+}) {
   return (
-    <Button asChild className="flex w-full items-center p-6">
-      <Link href={href}>
-        {children}
-        <ChevronRightIcon className="ml-auto h-6 w-6" />
+    <div
+      className={`flex h-24 w-full p-4 ${backgroundColor} rounded-lg text-white`}
+    >
+      <Link
+        href={href}
+        className="flex h-full w-full flex-row items-start justify-between"
+      >
+        <div className="flex h-full min-w-0 flex-1 flex-col pr-4 text-left lg:gap-2">
+          <h2 className="text-lg font-bold">{children}</h2>
+          <p className="break-words text-xs">{description}</p>
+        </div>
+        <div className="ml-6 flex h-full flex-shrink-0 items-center">
+          {icon}
+        </div>
       </Link>
-    </Button>
+    </div>
   );
 }
 
 export default async function Home() {
   return (
-    <div className="flex flex-col items-center">
-      <ul className="flex w-full max-w-[80%] flex-col gap-3">
+    <div className="mt-6 flex flex-col items-center">
+      <ul className="flex w-full max-w-[80%] flex-col gap-6">
         <LinkListItem>
-          <StyledLink href="/recent/nearby">See nearby sightings</StyledLink>
+          <StyledLink
+            href="/recent/nearby"
+            description="Map view of bird sightings wherever you want to look"
+            backgroundColor="bg-primary"
+            icon={<MapIcon className="h-full w-full" />}
+          >
+            Nearby Birds
+          </StyledLink>
         </LinkListItem>
         <LinkListItem>
-          <StyledLink href="/recent/region">Search by Region</StyledLink>
+          <StyledLink
+            href="/recent/region"
+            description="Search bird sightings in a specific city, town, or state"
+            backgroundColor="bg-secondary"
+            icon={<MagnifyingGlassCircleIcon className="h-full w-full" />}
+          >
+            Region Search
+          </StyledLink>
         </LinkListItem>
       </ul>
     </div>


### PR DESCRIPTION
#Description

- Changed homepage card design. Uses same component structure but StyledLink has been altered significantly.
- primary & secondary colours slightly more varied and are slightly closer according to [contrastfinder](https://app.contrast-finder.org/result.html?foreground=%23FFFFFF&background=%23ED6D12&ratio=7&isBackgroundTested=false&algo=HSV&lang=en) than before. (Previous contrast score was 2.37 with the white against the orange)
- Added "bird" into the centre of the navbar as a heading.
- Whole app background colour changed to an off-white.

**Before**
<img width="444" alt="Screenshot 2025-05-27 at 12 08 13" src="https://github.com/user-attachments/assets/e0095e12-c59e-4435-8bc5-64695353998b" />

**After**
<img width="443" alt="Screenshot 2025-05-27 at 12 07 53" src="https://github.com/user-attachments/assets/5ff8465a-4c06-40f3-885e-27e5f98c40d6" />

